### PR TITLE
Adds tests for GenericWork, Vocabulary and Term Views; adds tests for Vocabulary and Term Models

### DIFF
--- a/app/views/curation_concerns/generic_works/show.json.jbuilder
+++ b/app/views/curation_concerns/generic_works/show.json.jbuilder
@@ -19,7 +19,7 @@ json.uses_vocabulary @vocabularies do |vocabulary|
   end
 end
 json.form @curation_concern.class.properties.each do |property|
-  json.authorities Vocabulary.controls_for(property.last) do |authority|
+  json.authorities LafayetteConcerns::Vocabulary.controls_for(property.last) do |authority|
     json.uri authority.rdf_subject.to_s
     json.absolute_path authority.absolute_path
   end

--- a/app/views/curation_concerns/generic_works/update.json.jbuilder
+++ b/app/views/curation_concerns/generic_works/update.json.jbuilder
@@ -19,7 +19,7 @@ json.uses_vocabulary @vocabularies do |vocabulary|
   end
 end
 json.form @curation_concern.class.properties.each do |property|
-  json.authorities Vocabulary.controls_for(property.last) do |authority|
+  json.authorities LafayetteConcerns::Vocabulary.controls_for(property.last) do |authority|
     json.uri authority.rdf_subject.to_s
     json.absolute_path authority.absolute_path
   end

--- a/app/views/lafayette_concerns/terms/update.json.jbuilder
+++ b/app/views/lafayette_concerns/terms/update.json.jbuilder
@@ -1,0 +1,5 @@
+json.uri @term.rdf_subject.to_s
+json.label @term.label
+json.alt_label @term.alt_label
+json.pref_label @term.pref_label
+json.hidden_label @term.hidden_label

--- a/spec/controllers/lafayette_concerns/vocabularies_controller_spec.rb
+++ b/spec/controllers/lafayette_concerns/vocabularies_controller_spec.rb
@@ -4,73 +4,118 @@ describe LafayetteConcerns::VocabulariesController, :type => :controller do
   let(:user) { create(:user) }
   before { sign_in user }
 
-  before(:example) do
-    @vocab = LafayetteConcerns::Vocabulary.new('http://authority.localhost.localdomain/ns/testVocabulary')
-    @vocab.persist!
-    @term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/testVocabulary/testTerm')
-    @term.persist!
-  end
-
-  after(:example) do
-    @term.destroy
-    @vocab.destroy
-  end
-
   context "JSON" do
-#    let(:resource) { LafayetteConcerns::Vocabulary.new('http://authority.localhost.localdomain/ns/testVocabulary').persist! }
-#    let(:term_resource) { LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/testVocabulary/testTerm').persist! }
+    before() do
+      @vocabulary = LafayetteConcerns::Vocabulary.new('http://authority.localhost.localdomain/ns/testVocabulary')
+      @vocabulary.persist!
+    end
 
-#    let(:resource) { create(:vocabulary) }
-#    let(:term_resource) { create(:term) }
+    after { @vocabulary.destroy }
 
-#    let(:resource_request) { get :show, params: { id: resource, format: :json } }
-#    let(:resource) { create(:private_generic_work, user: user) }
+    describe 'retrieving the attributes of a term' do
+      before do
+        get :show, vocabulary_id: 'testVocabulary', id: 'testVocabulary', format: :json
+      end
+      subject { response }        
+
+      it "gets the attributes" do
+        expect(controller).to render_template(:show)
+        expect(response.code).to eq "200"
+        expect(assigns[:vocabulary]).to be_instance_of LafayetteConcerns::Vocabulary
+        created_resource = assigns[:vocabulary]
+        expect(created_resource.rdf_subject).to eq("http://authority.localhost.localdomain/ns/testVocabulary")
+      end
+    end    
 
     describe 'replacing the attributes of a vocabulary with no terms' do
       before { put :update, id: 'testVocabulary', vocabulary: { label: ['replaced label'], terms: [] }, format: :json }
       subject { response }
 
-      it "returns 200" do
-
+      it "renders the updated gets attribute and empty terms" do
+        expect(controller).to render_template(:update)
         expect(response.code).to eq "200"
+        expect(assigns[:vocabulary]).to be_instance_of LafayetteConcerns::Vocabulary
+        created_resource = assigns[:vocabulary]
+        expect(created_resource.rdf_subject).to eq("http://authority.localhost.localdomain/ns/testVocabulary")
+        expect(created_resource.label).to eq(["replaced label"])
+        expect(created_resource.children).to eq([])
       end
     end
 
     describe 'replacing a vocabulary with different attributes and terms' do
-      before { put :update, id: 'testVocabulary', vocabulary: { label: ['replaced label'], terms: [ { uri: 'http://authority.localhost.localdomain/ns/testVocabulary/testTerm', label: ['replaced term label'] } ] }, format: :json }
-      subject { response }
-      it "returns 200" do
+      before do
+        @term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/testVocabulary/testTerm')
+        @term.persist!
+        
+        put :update, id: 'testVocabulary', vocabulary: { label: ['replaced label'], terms: [ { uri: 'http://authority.localhost.localdomain/ns/testVocabulary/testTerm', label: ['replaced term label'] } ] }, format: :json
+      end
 
+      after do
+        @term.destroy
+      end
+
+      subject { response }
+
+      it "renders the new attributes and newly assigned terms" do
+
+        expect(controller).to render_template(:update)
         expect(response.code).to eq "200"
+        expect(assigns[:vocabulary]).to be_instance_of LafayetteConcerns::Vocabulary
+        created_resource = assigns[:vocabulary]
+        expect(created_resource.rdf_subject).to eq("http://authority.localhost.localdomain/ns/testVocabulary")
+        expect(created_resource.label).to eq(["replaced label"])
+        expect(created_resource.children.size).to eq(1)
+        expect(created_resource.children.first).to be_instance_of LafayetteConcerns::Term
+        expect(created_resource.children.first.rdf_subject).to eq('http://authority.localhost.localdomain/ns/testVocabulary/testTerm')
+        expect(created_resource.children.first.label).to eq(['replaced term label'])
       end
     end
 
     describe 'replacing a vocabulary using a foreign (or non-existent) term' do
       before { put :update, id: 'testVocabulary', vocabulary: { label: ['replaced label'], terms: [ { uri: 'http://authority.localhost.localdomain/ns/anotherVocabulary/testTerm', label: ['replaced term label'] } ] }, format: :json }
       subject { response }
-      it "returns 400" do
+      it "returns raises an error for the foreign term" do
 
         expect(response.code).to eq "400"
       end
+      
     end
 
     describe 'updating the attributes for a vocabulary' do
       before { patch :update, id: 'testVocabulary', vocabulary: { label: ['updated label'], alt_label: ['updated alternate label'] }, format: :json }
       subject { response }
-      it "returns 200, renders show template sets location header" do
 
+      it "renders the updated gets attribute and empty terms" do
+        expect(controller).to render_template(:update)
         expect(response.code).to eq "200"
-      end
+        expect(assigns[:vocabulary]).to be_instance_of LafayetteConcerns::Vocabulary
+        created_resource = assigns[:vocabulary]
+        expect(created_resource.rdf_subject).to eq("http://authority.localhost.localdomain/ns/testVocabulary")
+        expect(created_resource.label).to eq(["updated label"])
+        expect(created_resource.alt_label).to eq(["updated alternate label"])
+
+      end        
+
     end
 
     describe 'updating the terms for a vocabulary' do
       before { patch :update, id: 'testVocabulary', vocabulary: { label: ['updated label'], alt_label: ['updated alternate label'], terms: [ { uri: 'http://authority.localhost.localdomain/ns/testVocabulary/testTerm', label: ['updated term label'] } ] }, format: :json }
       subject { response }
-      it "returns 200, renders show template sets location header" do
 
+      it "renders the new attributes and newly assigned terms" do
+
+        expect(controller).to render_template(:update)
         expect(response.code).to eq "200"
-
-      end
+        expect(assigns[:vocabulary]).to be_instance_of LafayetteConcerns::Vocabulary
+        created_resource = assigns[:vocabulary]
+        expect(created_resource.rdf_subject).to eq("http://authority.localhost.localdomain/ns/testVocabulary")
+        expect(created_resource.label).to eq(["updated label"])
+        expect(created_resource.alt_label).to eq(["updated alternate label"])
+        expect(created_resource.children.size).to eq(1)
+        expect(created_resource.children.first).to be_instance_of LafayetteConcerns::Term
+        expect(created_resource.children.first.rdf_subject).to eq('http://authority.localhost.localdomain/ns/testVocabulary/testTerm')
+        expect(created_resource.children.first.label).to eq(['updated term label'])
+      end      
     end
   end
 end

--- a/spec/models/lafayette_concerns/term_spec.rb
+++ b/spec/models/lafayette_concerns/term_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe LafayetteConcerns::Term do
+
+  it 'has a label' do
+    subject.label = ['foo']
+    expect(subject.label).to eq ['foo']
+  end
+
+  context 'with a URI' do
+    before do
+      subject.uri = 'http://authority.localhost.localdomain/ns/newVocabulary/newTerm'
+    end
+    
+    it 'has a namespace' do
+      expect(subject.namespace).to eq('http://authority.localhost.localdomain/ns/')
+    end
+  end
+end

--- a/spec/models/lafayette_concerns/vocabulary_spec.rb
+++ b/spec/models/lafayette_concerns/vocabulary_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe LafayetteConcerns::Vocabulary do
+
+  it 'has a label' do
+    subject.label = ['foo']
+    expect(subject.label).to eq ['foo']
+  end
+
+  context 'referencing child terms' do
+    before do
+      subject.uri = 'http://authority.localhost.localdomain/ns/newVocabulary'
+      
+      @term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/newVocabulary/testTerm')
+      @term.persist!
+
+      @second_term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/newVocabulary/testTerm2')
+      @second_term.persist!
+
+      @foreign_term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/anotherVocabulary/testTerm')
+    end
+
+    after do
+      @term.destroy
+    end
+
+    it 'can detemine if it has a child term' do
+
+      expect(subject.include?(@term)).to be true
+      expect(subject.include?(@foreign_term)).to be false
+    end
+
+    it 'can have multiple child terms' do
+
+      expect(subject.children).to include(@term)
+      expect(subject.children).to include(@second_term)
+    end
+  end
+end

--- a/spec/views/curation_concerns/generic_works/show.json.jbuilder_spec.rb
+++ b/spec/views/curation_concerns/generic_works/show.json.jbuilder_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'curation_concerns/generic_works/show.json.jbuilder' do
+
+  let(:curation_concern) { FactoryGirl.create(:work_with_representative_file) }
+
+  before do
+    curation_concern.thumbnail = curation_concern.ordered_members.to_a.last
+    assign(:curation_concern, curation_concern)
+    render
+  end
+
+  it "renders json of the curation_concern" do
+    json = JSON.parse(rendered)
+    expect(json['id']).to eq curation_concern.id
+    expect(json['title']).to eq curation_concern.title
+  end
+end

--- a/spec/views/curation_concerns/generic_works/update.json.jbuilder_spec.rb
+++ b/spec/views/curation_concerns/generic_works/update.json.jbuilder_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'curation_concerns/generic_works/update.json.jbuilder' do
+
+  let(:curation_concern) { FactoryGirl.create(:work_with_representative_file) }
+
+  before do
+    curation_concern.thumbnail = curation_concern.ordered_members.to_a.last
+    assign(:curation_concern, curation_concern)
+    render
+  end
+
+  it "renders json of the curation_concern" do
+    json = JSON.parse(rendered)
+    expect(json['id']).to eq curation_concern.id
+    expect(json['title']).to eq curation_concern.title
+  end
+end

--- a/spec/views/lafayette_concerns/terms/show.json.jbuilder_spec.rb
+++ b/spec/views/lafayette_concerns/terms/show.json.jbuilder_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'lafayette_concerns/terms/show.json.jbuilder' do
+  let(:term) do
+    term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/testVocabulary/testTerm')
+    term.persist!
+    term
+  end
+
+  before do
+    assign(:term, term)
+    render
+  end
+
+  it "renders JSON of the term" do
+    json = JSON.parse(rendered)
+    expect(json['uri']).to eq term.uri
+    expect(json['label']).to match_array term.label
+    expect(json['alt_label']).to match_array term.alt_label
+    expect(json['pref_label']).to match_array term.pref_label
+    expect(json['hidden_label']).to match_array term.hidden_label
+  end
+end

--- a/spec/views/lafayette_concerns/terms/update.json.jbuilder_spec.rb
+++ b/spec/views/lafayette_concerns/terms/update.json.jbuilder_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'lafayette_concerns/terms/update.json.jbuilder' do
+  let(:term) do
+    term = LafayetteConcerns::Term.new('http://authority.localhost.localdomain/ns/testVocabulary/testTerm')
+    term.persist!
+    term
+  end
+
+  before do
+    assign(:term, term)
+    render
+  end
+
+  it "renders JSON of the term" do
+    json = JSON.parse(rendered)
+    expect(json['uri']).to eq term.uri
+    expect(json['label']).to match_array term.label
+    expect(json['alt_label']).to match_array term.alt_label
+    expect(json['pref_label']).to match_array term.pref_label
+    expect(json['hidden_label']).to match_array term.hidden_label
+  end
+end

--- a/spec/views/lafayette_concerns/vocabularies/update.json.jbuilder_spec.rb
+++ b/spec/views/lafayette_concerns/vocabularies/update.json.jbuilder_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'lafayette_concerns/vocabularies/update.json.jbuilder' do
+  let(:vocabulary) do
+    vocab = LafayetteConcerns::Vocabulary.new('http://authority.localhost.localdomain/ns/testVocabulary')
+    vocab.persist!
+    vocab
+  end
+
+  before do
+    assign(:vocabulary, vocabulary)
+    render
+  end
+
+  it "renders JSON of the vocabulary" do
+    json = JSON.parse(rendered)
+    expect(json['uri']).to eq vocabulary.uri
+    expect(json['label']).to match_array vocabulary.label
+    expect(json['alt_label']).to match_array vocabulary.alt_label
+    expect(json['pref_label']).to match_array vocabulary.pref_label
+    expect(json['hidden_label']).to match_array vocabulary.hidden_label
+  end
+end


### PR DESCRIPTION
Implementing test suites for the GenericWork, Vocabulary and Term Views; implementing tests for the Vocabulary and Term Models; Cleaning and improving the coverage the Vocabularies Controller